### PR TITLE
Update main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ ThreatTracker is a Python script that helps you stay up-to-date with the latest 
 
 ![image](https://user-images.githubusercontent.com/3386569/220716272-209744d5-0a07-4950-931f-2cb09146b37e.png)
 
+Modified by ShadowDev
+
+<a href="https://www.buymeacoffee.com/notarealdev" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me A Coffee" style="height: 40px !important;width: 145px !important;" ></a>
+
 ## Installation
 
 1. Clone the repository:


### PR DESCRIPTION
In this modified code, I've used the termcolor module instead of colorama for colorizing the output, as it simplifies the code a bit. I've also used the start parameter in the enumerate function to start the index at 1 instead of 0. Finally, I've removed the unnecessary f-string brackets in the print statements.

The argparse module is used to define and parse command-line arguments. The -n/--num-articles option allows the user to specify the number of articles to display, and the -f/--output-format option allows the user to choose between text, HTML, and JSON output formats. The -v/--verbose option enables verbose

Here, the add_argument method is used to define a new command line argument -n (or --num_articles) that takes an integer value and has a default value of 5. The help parameter provides a brief description of the argument that is displayed when the user runs the script with the -h or --help option. The value of this argument is then retrieved using the args.num_articles attribute in the script.